### PR TITLE
Remove polyfill.io script tag (compromised domain phishing visitors)

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,7 +13,6 @@
 	<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
 	<link rel="stylesheet" href="assets/css/main.css" />
 
-	<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
 	<script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </head>
 


### PR DESCRIPTION
## What happened

Visitors to the homepage were being shown a native browser sign-in dialog:

> *"polyfill.io — This site is asking you to sign in. Warning: Your login information will be shared with polyfill.io, not the website you are currently visiting."*

The cause is the script tag in `index.html`:

```html
<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
```

## Background: the polyfill.io incident

- **February 2024:** The polyfill.io domain and its GitHub account were sold to Funnull, a Chinese CDN company.
- **June 2024:** Researchers ([Sansec](https://sansec.io/research/polyfill-supply-chain-attack), [Qualys](https://blog.qualys.com/vulnerabilities-threat-research/2024/06/28/polyfill-io-supply-chain-attack)) discovered the domain serving **malicious code** to the 100,000+ websites embedding it — a major supply-chain attack. The script selectively targeted mobile users and redirected them to scam sites via a typosquatted Google Analytics domain. The registrar suspended the domain shortly after; universal guidance since then has been to [remove all references to polyfill.io](https://www.kaspersky.com/blog/polyfill-io-service-supply-chain-attacks/51635/).
- **Late May 2026:** The domain **became active again** and now responds with HTTP 401, which makes browsers display a "sign in to polyfill.io" Basic-auth prompt on every page that still embeds the script. This is treated as a [credential-harvesting campaign](https://techjacksolutions.com/scc-intel/polyfill-io-cdn-reactivation-triggers-credential-harvesting-login-prompts-on-major-brand-sites/) and has hit major sites like [Toshiba and MUJI](https://www.bleepingcomputer.com/news/security/suspicious-polyfill-login-prompts-pop-up-on-toshiba-muji-websites/). In effect, any site still referencing polyfill.io is [phishing its own visitors](https://lokker.com/blog/polyfill-hijack-update).

## Why removal (without replacement) is safe

The tag came from old MathJax setup instructions: it provided ES6 polyfills for Internet Explorer 11. Every browser in current use supports ES6 natively, and MathJax 3 (loaded from jsDelivr) does not need it.

The other `polyfill` mentions in the repo (`assets/js/util.js`, `assets/js/main.js`, slide decks) are local template code shipped with the site — they never contact polyfill.io and are unaffected.

## Verification

Served the site locally and rendered it in headless Chrome after the change:

- Layout, avatar, navigation, publication figures all render correctly.
- All 36 MathJax expressions typeset correctly (including the \(\mathbb{RP}^2\)-knot notation in the Low-dimensional Topology section); zero MathJax error elements.
- No JavaScript console errors or failed resource loads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)